### PR TITLE
fix: Gcm InternalServerError should also be retied with exponential-back-off.

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -33,7 +33,8 @@ var Constants = {
     'ERROR_NOT_REGISTERED' : 'NotRegistered',
     'ERROR_MESSAGE_TOO_BIG' : 'MessageTooBig',
     'ERROR_MISSING_COLLAPSE_KEY' : 'MissingCollapseKey',
-    'ERROR_UNAVAILABLE' : 'Unavailable'
+    'ERROR_UNAVAILABLE' : 'Unavailable',
+    'ERROR_INTERNAL_SERVER_ERROR' : 'InternalServerError'
 
     /** END DEPRECATED **/
 };

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -106,7 +106,7 @@ function checkForBadTokens(results, originalRecipients, callback) {
     var unsentRegTokens = [];
     var regTokenPositionMap = [];
     for (var i = 0; i < results.length; i++) {
-        if (results[i].error === 'Unavailable') {
+        if (results[i].error === 'Unavailable' || results[i].error === 'InternalServerError') {
             regTokenPositionMap.push(i);
             unsentRegTokens.push(originalRecipients[i]);
         }


### PR DESCRIPTION
as per the [Firebase Error Code](https://firebase.google.com/docs/cloud-messaging/http-server-ref#error-codes) "InternalServerError" should be retired similar to "Unavailable" error.